### PR TITLE
Fix typo in import

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Then using this converter let's concatenate all the text within the ebooks into 
 
 You can also proceed line by line:
 
-	from epub_conversion.utils import open_book
+	from epub_conversion.utils import open_book, convert_epub_to_lines
 
 	book = open_book("twilight.epub")
 

--- a/epub_conversion/utils.py
+++ b/epub_conversion/utils.py
@@ -1,7 +1,7 @@
 import os
 from xml_cleaner import to_raw_text
 from epub import open_epub, BadEpubFile
-from zipfile import BadZipFile
+from zipfile import BadZipfile
 
 def get_files_from_path(filetype, path):
 	"""

--- a/epub_conversion/utils.py
+++ b/epub_conversion/utils.py
@@ -35,7 +35,7 @@ def try_decode(ebook, item):
 def open_book(path):
 	try:
 		return open_epub(path)
-	except (BadEpubFile, BadZipFile, KeyError, IndexError):
+	except (BadEpubFile, BadZipfile, KeyError, IndexError):
 		return None
 
 def convert_xml_element_to_lines(data, boundary):


### PR DESCRIPTION
The exception in the `zipfile` package is called `zipfile.BadZipfile`, not `zipfile.BadZipFile`. Source: https://docs.python.org/2/library/zipfile.html#zipfile.BadZipfile

When I use this out of the box, I get an import error. Fixing the typo fixes the import error.